### PR TITLE
Rearrange modules

### DIFF
--- a/rfluids/src/error.rs
+++ b/rfluids/src/error.rs
@@ -1,6 +1,10 @@
-//! Error handling.
-
-use crate::io::{FluidParam, FluidTrivialParam, HumidAirParam};
+use crate::{
+    fluid::{FluidFromCustomMixError, FluidOutputError, FluidStateError},
+    humid_air::{HumidAirOutputError, HumidAirStateError},
+    io::AltitudeError,
+    native::CoolPropError,
+    substance::{BinaryMixError, CustomMixError},
+};
 use thiserror::Error;
 
 /// Superset of all possible errors that can occur in the library.
@@ -47,117 +51,4 @@ pub enum Error {
     /// [`HumidAir`](crate::humid_air::HumidAir) output parameter value.
     #[error(transparent)]
     HumidAirOutput(#[from] HumidAirOutputError),
-}
-
-/// `CoolProp` internal error.
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
-#[error("{0}")]
-pub struct CoolPropError(pub(crate) String);
-
-/// Error during creation of [`BinaryMix`](crate::substance::BinaryMix).
-#[derive(Error, Debug, Clone, PartialEq)]
-pub enum BinaryMixError {
-    /// Specified fraction is invalid.
-    #[error("Specified fraction `{specified:?}` is out of possible range [{min:.1}; {max:.1}]!")]
-    InvalidFraction {
-        /// Specified value.
-        specified: f64,
-        /// Minimum possible value.
-        min: f64,
-        /// Maximum possible value.
-        max: f64,
-    },
-}
-
-/// Error during creation of [`CustomMix`](crate::substance::CustomMix).
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum CustomMixError {
-    /// The specified components are not enough.
-    #[error("At least 2 unique components must be provided!")]
-    NotEnoughComponents,
-
-    /// Some of the specified fractions are invalid.
-    #[error("All of the specified fractions must be exclusive between 0 and 1!")]
-    InvalidFraction,
-
-    /// The sum of the specified fractions is invalid.
-    #[error("The sum of the specified fractions must be equal to 1!")]
-    InvalidFractionsSum,
-}
-
-/// Error during creation of [`Fluid`](crate::fluid::Fluid)
-/// from [`CustomMix`](crate::substance::CustomMix).
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum FluidFromCustomMixError {
-    /// Specified custom mixture is not supported.
-    #[error("Specified custom mixture is not supported! {0}")]
-    Unsupported(#[from] CoolPropError),
-}
-
-/// Error during [`Fluid::update`](crate::fluid::Fluid::update)
-/// or [`Fluid::in_state`](crate::fluid::Fluid::in_state).
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum FluidStateError {
-    /// Specified inputs are invalid.
-    #[error("Specified inputs (`{0:?}`, `{1:?}`) are invalid!")]
-    InvalidInputPair(FluidParam, FluidParam),
-
-    /// Some of the specified input value is infinite or NaN.
-    #[error("Input values must be finite!")]
-    InvalidInputValue,
-
-    /// Failed to update the fluid state due to unsupported inputs or invalid state.
-    #[error("Failed to update the fluid state! {0}")]
-    UpdateFailed(#[from] CoolPropError),
-}
-
-/// Error during calculation of the
-/// [`Fluid`](crate::fluid::Fluid) output parameter value.
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum FluidOutputError {
-    /// Specified trivial output parameter is not available.
-    #[error("Specified trivial output parameter `{0:?}` is not available!")]
-    UnavailableTrivialOutput(FluidTrivialParam),
-
-    /// Specified output parameter is not available.
-    #[error("Specified output parameter `{0:?}` is not available!")]
-    UnavailableOutput(FluidParam),
-
-    /// Failed to calculate the output parameter value.
-    #[error("Failed to calculate the output value of `{0:?}`! {1}")]
-    CalculationFailed(FluidParam, CoolPropError),
-}
-
-/// Error during [`HumidAirInput::altitude`](crate::io::HumidAirInput::altitude).
-#[derive(Error, Debug, Clone, PartialEq)]
-pub enum AltitudeError {
-    /// Altitude value is out of possible range.
-    #[error("Altitude value `{0:?} m` is out of possible range [-5 000; 10 000] m!")]
-    OutOfRange(f64),
-}
-
-/// Error during [`HumidAir::update`](crate::humid_air::HumidAir::update)
-/// or [`HumidAir::in_state`](crate::humid_air::HumidAir::in_state).
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum HumidAirStateError {
-    /// Specified inputs are invalid.
-    #[error("Specified inputs (`{0:?}`, `{1:?}`, `{2:?}`) are invalid!")]
-    InvalidInputs(HumidAirParam, HumidAirParam, HumidAirParam),
-
-    /// Some of the specified input value is infinite or NaN.
-    #[error("Input values must be finite!")]
-    InvalidInputValue,
-}
-
-/// Error during calculation of the
-/// [`HumidAir`](crate::humid_air::HumidAir) output parameter value.
-#[derive(Error, Debug, Clone, Eq, PartialEq)]
-pub enum HumidAirOutputError {
-    /// Specified output parameter is not available.
-    #[error("Specified output parameter `{0:?}` is not available!")]
-    UnavailableOutput(HumidAirParam),
-
-    /// Failed to calculate the output parameter value.
-    #[error("Failed to calculate the output value of `{0:?}`! {1}")]
-    CalculationFailed(HumidAirParam, CoolPropError),
 }

--- a/rfluids/src/fluid/common.rs
+++ b/rfluids/src/fluid/common.rs
@@ -1,8 +1,7 @@
-use super::OutputResult;
+use super::{FluidOutputError, OutputResult};
 use crate::{
-    error::{CoolPropError, FluidOutputError},
     io::{FluidParam, FluidTrivialParam},
-    native::AbstractState,
+    native::{AbstractState, CoolPropError},
 };
 use std::{collections::HashMap, hash::Hash};
 

--- a/rfluids/src/fluid/defined.rs
+++ b/rfluids/src/fluid/defined.rs
@@ -1,11 +1,10 @@
 // cSpell:disable
 
 use super::{
-    Fluid, OutputResult, StateResult,
+    Fluid, FluidOutputError, OutputResult, StateResult,
     common::{cached_output, guard},
 };
 use crate::{
-    error::FluidOutputError,
     io::{FluidInput, FluidParam, Phase},
     ops::div,
 };
@@ -558,7 +557,7 @@ impl Fluid {
     /// # Errors
     ///
     /// For invalid/unsupported inputs or invalid state,
-    /// a [`FluidStateError`](crate::error::FluidStateError) is returned.
+    /// a [`FluidStateError`](crate::fluid::FluidStateError) is returned.
     ///
     /// # Examples
     ///
@@ -593,7 +592,7 @@ impl Fluid {
     ///     FluidInput::temperature(353.15),
     /// );
     /// assert!(new_water.is_ok());
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     ///
     /// # See also
@@ -614,7 +613,7 @@ impl Fluid {
     /// # Errors
     ///
     /// For invalid/unsupported inputs or invalid state,
-    /// a [`FluidStateError`](crate::error::FluidStateError) is returned.
+    /// a [`FluidStateError`](crate::fluid::FluidStateError) is returned.
     ///
     /// # Examples
     ///
@@ -649,7 +648,7 @@ impl Fluid {
     ///     FluidInput::temperature(353.15),
     /// );
     /// assert!(new_water.is_ok());
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     ///
     /// # See also
@@ -704,7 +703,7 @@ impl PartialEq for Fluid {
 mod tests {
     use super::*;
     use crate::{
-        error::FluidStateError,
+        fluid::FluidStateError,
         substance::*,
         test::{assert_relative_eq, test_output},
     };

--- a/rfluids/src/fluid/invariant.rs
+++ b/rfluids/src/fluid/invariant.rs
@@ -1,10 +1,9 @@
 use super::{
-    Fluid, OutputResult, StateResult,
+    Fluid, FluidOutputError, OutputResult, StateResult,
     common::{cached_output, guard},
     requests::FluidUpdateRequest,
 };
 use crate::{
-    error::FluidOutputError,
     io::{FluidInput, FluidTrivialParam},
     ops::mul,
     state_variant::StateVariant,

--- a/rfluids/src/fluid/requests.rs
+++ b/rfluids/src/fluid/requests.rs
@@ -1,5 +1,5 @@
+use super::FluidStateError;
 use crate::{
-    error::FluidStateError,
     io::{FluidInput, FluidInputPair, FluidParam},
     substance::{BackendName, Substance},
 };

--- a/rfluids/src/fluid/undefined.rs
+++ b/rfluids/src/fluid/undefined.rs
@@ -14,7 +14,7 @@ impl Fluid<Undefined> {
     /// # Errors
     ///
     /// For invalid/unsupported inputs or invalid state,
-    /// a [`FluidStateError`](crate::error::FluidStateError) is returned.
+    /// a [`FluidStateError`](crate::fluid::FluidStateError) is returned.
     ///
     /// # Examples
     ///
@@ -49,7 +49,7 @@ impl Fluid<Undefined> {
     ///     FluidInput::temperature(353.15),
     /// );
     /// assert!(new_water.is_ok());
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     ///
     /// # See also
@@ -86,7 +86,7 @@ impl PartialEq for Fluid<Undefined> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{error::FluidStateError, substance::*, test::test_output};
+    use crate::{fluid::FluidStateError, substance::*, test::test_output};
     use rstest::*;
 
     #[fixture]

--- a/rfluids/src/humid_air/common.rs
+++ b/rfluids/src/humid_air/common.rs
@@ -1,5 +1,5 @@
-use super::{OutputResult, requests::HumidAirUpdateRequest};
-use crate::{error::HumidAirOutputError, io::HumidAirParam, native::CoolProp};
+use super::{HumidAirOutputError, OutputResult, requests::HumidAirUpdateRequest};
+use crate::{io::HumidAirParam, native::CoolProp};
 use std::collections::HashMap;
 
 pub(crate) fn cached_output(

--- a/rfluids/src/humid_air/defined.rs
+++ b/rfluids/src/humid_air/defined.rs
@@ -13,7 +13,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn abs_humidity(&mut self) -> OutputResult<f64> {
         self.non_negative_output(HumidAirParam::W)
     }
@@ -25,7 +25,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn density(&mut self) -> OutputResult<f64> {
         self.specific_volume().map(|value| 1.0 / value)
     }
@@ -37,7 +37,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn density_da(&mut self) -> OutputResult<f64> {
         self.specific_volume_da().map(|value| 1.0 / value)
     }
@@ -47,7 +47,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn compressibility(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Z)
     }
@@ -57,7 +57,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn conductivity(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Conductivity)
     }
@@ -67,7 +67,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn dew_temperature(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::TDew)
     }
@@ -77,7 +77,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn dynamic_viscosity(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::DynamicViscosity)
     }
@@ -87,7 +87,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn enthalpy(&mut self) -> OutputResult<f64> {
         self.output(HumidAirParam::Hha)
     }
@@ -97,7 +97,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn enthalpy_da(&mut self) -> OutputResult<f64> {
         self.output(HumidAirParam::Hda)
     }
@@ -107,7 +107,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn entropy(&mut self) -> OutputResult<f64> {
         self.output(HumidAirParam::Sha)
     }
@@ -117,7 +117,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn entropy_da(&mut self) -> OutputResult<f64> {
         self.output(HumidAirParam::Sda)
     }
@@ -127,7 +127,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn pressure(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::P)
     }
@@ -137,7 +137,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn rel_humidity(&mut self) -> OutputResult<f64> {
         let key = HumidAirParam::R;
         self.output(key)
@@ -149,7 +149,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn specific_heat(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Cpha)
     }
@@ -159,7 +159,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn specific_heat_da(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Cpda)
     }
@@ -169,7 +169,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn specific_heat_const_volume(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Cvha)
     }
@@ -179,7 +179,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn specific_heat_const_volume_da(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Cvda)
     }
@@ -189,7 +189,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn specific_volume(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Vha)
     }
@@ -199,7 +199,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn specific_volume_da(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::Vda)
     }
@@ -209,7 +209,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn temperature(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::T)
     }
@@ -219,7 +219,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn water_mole_fraction(&mut self) -> OutputResult<f64> {
         self.non_negative_output(HumidAirParam::PsiW)
     }
@@ -229,7 +229,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn water_partial_pressure(&mut self) -> OutputResult<f64> {
         self.non_negative_output(HumidAirParam::Pw)
     }
@@ -239,7 +239,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// If it's not available or calculation is failed,
-    /// a [`HumidAirOutputError`](crate::error::HumidAirOutputError) is returned.
+    /// a [`HumidAirOutputError`](crate::humid_air::HumidAirOutputError) is returned.
     pub fn wet_bulb_temperature(&mut self) -> OutputResult<f64> {
         self.positive_output(HumidAirParam::TWetBulb)
     }
@@ -255,7 +255,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// For invalid inputs,
-    /// a [`HumidAirStateError`](crate::error::HumidAirStateError) is returned.
+    /// a [`HumidAirStateError`](crate::humid_air::HumidAirStateError) is returned.
     ///
     /// # Examples
     ///
@@ -293,7 +293,7 @@ impl HumidAir {
     ///     HumidAirInput::rel_humidity(1.0),
     /// );
     /// assert!(new_humid_air.is_ok());
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     ///
     /// # See also
@@ -320,7 +320,7 @@ impl HumidAir {
     /// # Errors
     ///
     /// For invalid inputs,
-    /// a [`HumidAirStateError`](crate::error::HumidAirStateError) is returned.
+    /// a [`HumidAirStateError`](crate::humid_air::HumidAirStateError) is returned.
     ///
     /// # Examples
     ///
@@ -358,7 +358,7 @@ impl HumidAir {
     ///     HumidAirInput::rel_humidity(1.0),
     /// );
     /// assert!(new_humid_air.is_ok());
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     ///
     /// # See also
@@ -408,7 +408,7 @@ impl PartialEq for HumidAir {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{error::HumidAirStateError, test::test_output};
+    use crate::{humid_air::HumidAirStateError, test::test_output};
     use rstest::*;
 
     #[fixture]

--- a/rfluids/src/humid_air/requests.rs
+++ b/rfluids/src/humid_air/requests.rs
@@ -1,4 +1,5 @@
-use crate::{error::HumidAirStateError, io::HumidAirInput};
+use super::HumidAirStateError;
+use crate::io::HumidAirInput;
 use std::collections::HashSet;
 
 #[derive(Debug, Copy, Clone, PartialEq)]

--- a/rfluids/src/humid_air/undefined.rs
+++ b/rfluids/src/humid_air/undefined.rs
@@ -26,7 +26,7 @@ impl HumidAir<Undefined> {
     /// # Errors
     ///
     /// For invalid inputs,
-    /// a [`HumidAirStateError`](crate::error::HumidAirStateError) is returned.
+    /// a [`HumidAirStateError`](crate::humid_air::HumidAirStateError) is returned.
     ///
     /// # Examples
     ///
@@ -64,7 +64,7 @@ impl HumidAir<Undefined> {
     ///     HumidAirInput::rel_humidity(1.0),
     /// );
     /// assert!(new_humid_air.is_ok());
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     ///
     /// # See also
@@ -107,7 +107,7 @@ impl PartialEq for HumidAir<Undefined> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{error::HumidAirStateError, io::HumidAirInput};
+    use crate::{humid_air::HumidAirStateError, io::HumidAirInput};
     use rstest::*;
 
     #[fixture]

--- a/rfluids/src/io/humid_air_input.rs
+++ b/rfluids/src/io/humid_air_input.rs
@@ -1,5 +1,5 @@
 use super::{HumidAirParam, Input};
-use crate::error::AltitudeError;
+use thiserror::Error;
 
 /// [`HumidAir`](crate::humid_air::HumidAir) input parameter with specified value.
 ///
@@ -175,6 +175,14 @@ impl HumidAirInput {
             value,
         }
     }
+}
+
+/// Error during [`HumidAirInput::altitude`].
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum AltitudeError {
+    /// Altitude value is out of possible range.
+    #[error("Altitude value `{0:?} m` is out of possible range [-5 000; 10 000] m!")]
+    OutOfRange(f64),
 }
 
 #[cfg(test)]

--- a/rfluids/src/lib.rs
+++ b/rfluids/src/lib.rs
@@ -50,7 +50,7 @@
 //!     2_079.937_085_633_241,
 //!     max_relative = 1e-6
 //! );
-//! # Ok::<(), rfluids::error::Error>(())
+//! # Ok::<(), rfluids::Error>(())
 //! ```
 //!
 //! Dynamic viscosity **\[Pa·s\]** of propylene glycol aqueous solution
@@ -71,7 +71,7 @@
 //!     0.139_073_910_539_388_78,
 //!     max_relative = 1e-6
 //! );
-//! # Ok::<(), rfluids::error::Error>(())
+//! # Ok::<(), rfluids::Error>(())
 //! ```
 //!
 //! Density **\[kg/m³\]** of ethanol aqueous solution (with ethanol _40 %_ mass fraction)
@@ -96,7 +96,7 @@
 //!     883.392_277_162_775_9,
 //!     max_relative = 1e-6
 //! );
-//! # Ok::<(), rfluids::error::Error>(())
+//! # Ok::<(), rfluids::Error>(())
 //! ```
 //!
 //! Wet-bulb temperature **\[K\]** of humid air
@@ -116,7 +116,7 @@
 //!     295.067_569_033_474_57,
 //!     max_relative = 1e-6
 //! );
-//! # Ok::<(), rfluids::error::Error>(())
+//! # Ok::<(), rfluids::Error>(())
 //! ```
 //!
 //! [`Fluid`](crate::fluid::Fluid) and [`HumidAir`](crate::humid_air::HumidAir)
@@ -143,7 +143,7 @@
 //!     HumidAirInput::rel_humidity(0.5),
 //! )?;
 //! assert_ne!(humid_air, another_humid_air);
-//! # Ok::<(), rfluids::error::Error>(())
+//! # Ok::<(), rfluids::Error>(())
 //! ```
 //!
 //! #### License
@@ -163,14 +163,17 @@
     clippy::missing_panics_doc
 )]
 
-pub mod error;
+pub use error::*;
+pub use state_variant::*;
+
+mod error;
 pub mod fluid;
 pub mod humid_air;
 pub mod io;
 pub mod native;
 mod ops;
 pub mod prelude;
-pub mod state_variant;
+mod state_variant;
 pub mod substance;
 #[cfg(test)]
 mod test;

--- a/rfluids/src/native/high_level_api.rs
+++ b/rfluids/src/native/high_level_api.rs
@@ -1,10 +1,9 @@
 // cSpell:disable
 
 use super::{
-    Result,
+    CoolPropError, Result,
     common::{COOLPROP, MessageBuffer, const_ptr_c_char},
 };
-use crate::error::CoolPropError;
 use core::ffi::c_char;
 use std::sync::MutexGuard;
 
@@ -43,7 +42,7 @@ impl CoolProp {
     ///
     /// let result = CoolProp::props_si("C", "P", 101_325.0, "Q", 1.0, "Water")?;
     /// assert_relative_eq!(result, 2_079.937_085_633_241, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// ## Incompressible binary mixtures
@@ -57,7 +56,7 @@ impl CoolProp {
     ///
     /// let result = CoolProp::props_si("V", "P", 100e3, "T", 253.15, "INCOMP::MPG-60%")?;
     /// assert_relative_eq!(result, 0.139_073_910_539_388_47, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// ## Custom mixtures
@@ -78,7 +77,7 @@ impl CoolProp {
     ///     "HEOS::Water[0.6]&Ethanol[0.4]",
     /// )?;
     /// assert_relative_eq!(result, 859.529_660_279_914_7, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// # See also
@@ -143,7 +142,7 @@ impl CoolProp {
     ///
     /// let result = CoolProp::ha_props_si("B", "P", 100e3, "T", 303.15, "R", 0.5)?;
     /// assert_relative_eq!(result, 295.120_036_536_265_6, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// # See also
@@ -199,7 +198,7 @@ impl CoolProp {
     ///
     /// let result = CoolProp::props1_si("Tcrit", "Water")?;
     /// assert_relative_eq!(result, 647.096, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// R32 100-year global warming potential **\[dimensionless\]**:
@@ -209,7 +208,7 @@ impl CoolProp {
     ///
     /// let result = CoolProp::props1_si("GWP100", "R32")?;
     /// assert_eq!(result, 675.0);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// # See also

--- a/rfluids/src/native/low_level_api.rs
+++ b/rfluids/src/native/low_level_api.rs
@@ -1,8 +1,7 @@
 use super::{
-    Result,
+    CoolPropError, Result,
     common::{COOLPROP, ErrorBuffer, const_ptr_c_char},
 };
-use crate::error::CoolPropError;
 use core::ffi::{c_char, c_long};
 
 /// `CoolProp` thread safe low-level API.
@@ -104,7 +103,7 @@ impl AbstractState {
     /// let mut propylene_glycol = AbstractState::new("INCOMP", "MPG")?;
     /// let result = propylene_glycol.set_fractions(&[0.6]);
     /// assert!(result.is_ok());
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// For custom mixtures:
@@ -115,7 +114,7 @@ impl AbstractState {
     /// let mut mixture = AbstractState::new("HEOS", "Water&Ethanol")?;
     /// let result = mixture.set_fractions(&[0.8, 0.2]);
     /// assert!(result.is_ok());
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     pub fn set_fractions(&mut self, fractions: &[f64]) -> Result<()> {
         let error = ErrorBuffer::default();
@@ -153,7 +152,7 @@ impl AbstractState {
     /// let mut water = AbstractState::new("HEOS", "Water")?;
     /// let result = water.update(FluidInputPair::PT, 101_325.0, 293.15);
     /// assert!(result.is_ok());
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// # See also
@@ -207,7 +206,7 @@ impl AbstractState {
     /// water.update(FluidInputPair::PQ, 101_325.0, 1.0)?;
     /// let result = water.keyed_output(FluidParam::CpMass)?;
     /// assert_relative_eq!(result, 2_079.937_085_633_241, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// ## Incompressible binary mixtures
@@ -224,7 +223,7 @@ impl AbstractState {
     /// propylene_glycol.update(FluidInputPair::PT, 100e3, 253.15)?;
     /// let result = propylene_glycol.keyed_output(FluidParam::DynamicViscosity)?;
     /// assert_relative_eq!(result, 0.139_073_910_539_388_47, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// ## Custom mixtures
@@ -241,7 +240,7 @@ impl AbstractState {
     /// mixture.update(FluidInputPair::PT, 200e3, 277.15)?;
     /// let result = mixture.keyed_output(FluidParam::DMass)?;
     /// assert_relative_eq!(result, 883.882_635_377_379_6, max_relative = 1e-6);
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// # See also
@@ -286,7 +285,7 @@ impl AbstractState {
     /// water.specify_phase(Phase::Gas)?;
     /// result = water.update(FluidInputPair::PT, 101_325.0, 293.15);
     /// assert!(result.is_err());
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// # See also
@@ -321,7 +320,7 @@ impl AbstractState {
     /// water.unspecify_phase();
     /// result = water.update(FluidInputPair::PT, 101_325.0, 293.15);
     /// assert!(result.is_ok());
-    /// # Ok::<(), rfluids::error::CoolPropError>(())
+    /// # Ok::<(), rfluids::native::CoolPropError>(())
     /// ```
     ///
     /// # See also

--- a/rfluids/src/native/mod.rs
+++ b/rfluids/src/native/mod.rs
@@ -10,13 +10,18 @@
 //! - [`CoolProp`] -- high-level API for simplified access to properties.
 //! - [`AbstractState`] -- low-level API for direct control and improved performance.
 
-use crate::error::CoolPropError;
 pub use high_level_api::CoolProp;
 pub use low_level_api::AbstractState;
+use thiserror::Error;
 
 mod common;
 mod high_level_api;
 mod low_level_api;
+
+/// `CoolProp` internal error.
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+#[error("{0}")]
+pub struct CoolPropError(pub(crate) String);
 
 /// A type alias for results returned by `CoolProp` native API.
 pub type Result<T> = std::result::Result<T, CoolPropError>;

--- a/rfluids/src/prelude.rs
+++ b/rfluids/src/prelude.rs
@@ -6,5 +6,8 @@ pub use crate::{
     io::{FluidInput, FluidInputPair, FluidParam, FluidTrivialParam, HumidAirInput, Input, Phase},
     native::{AbstractState, CoolProp},
     state_variant::*,
-    substance::*,
+    substance::{
+        BackendName, BinaryMix, BinaryMixKind, CustomMix, IncompPure, PredefinedMix, Pure,
+        Substance,
+    },
 };

--- a/rfluids/src/state_variant.rs
+++ b/rfluids/src/state_variant.rs
@@ -1,6 +1,4 @@
-﻿//! Thermodynamic states.
-
-use std::fmt::Debug;
+﻿use std::fmt::Debug;
 
 /// Thermodynamic state variant.
 pub trait StateVariant: Debug {}

--- a/rfluids/src/substance/backend_name.rs
+++ b/rfluids/src/substance/backend_name.rs
@@ -25,7 +25,7 @@ pub trait BackendName {
     ///     .backend_name(),
     ///     "HEOS"
     /// );
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     fn backend_name(&self) -> &'static str;
 }

--- a/rfluids/src/substance/binary_mix.rs
+++ b/rfluids/src/substance/binary_mix.rs
@@ -1,11 +1,11 @@
 // cSpell:disable
 
-use crate::error::BinaryMixError;
 use std::str::FromStr;
 use strum::EnumProperty;
 #[cfg(test)]
 use strum_macros::EnumIter;
 use strum_macros::{AsRefStr, EnumProperty, EnumString};
+use thiserror::Error;
 
 /// `CoolProp` incompressible binary mixtures _(mass-based or volume-based)_.
 ///
@@ -291,6 +291,21 @@ pub struct BinaryMix {
     pub kind: BinaryMixKind,
     /// Specified fraction **\[dimensionless, from 0 to 1\]**.
     pub fraction: f64,
+}
+
+/// Error during creation of [`BinaryMix`].
+#[derive(Error, Debug, Clone, PartialEq)]
+pub enum BinaryMixError {
+    /// Specified fraction is invalid.
+    #[error("Specified fraction `{specified:?}` is out of possible range [{min:.1}; {max:.1}]!")]
+    InvalidFraction {
+        /// Specified value.
+        specified: f64,
+        /// Minimum possible value.
+        min: f64,
+        /// Maximum possible value.
+        max: f64,
+    },
 }
 
 #[cfg(test)]

--- a/rfluids/src/substance/custom_mix.rs
+++ b/rfluids/src/substance/custom_mix.rs
@@ -1,6 +1,7 @@
 use super::{BackendName, Pure};
-use crate::{error::CustomMixError, io::FluidTrivialParam::MolarMass, native::AbstractState};
+use crate::{io::FluidTrivialParam::MolarMass, native::AbstractState};
 use std::collections::HashMap;
+use thiserror::Error;
 
 /// `CoolProp` custom mixture.
 ///
@@ -107,7 +108,7 @@ impl CustomMix {
     ///     (Pure::R125, 0.5),
     /// ]))?;
     /// assert_ne!(mass_based_mix.clone().into_mole_based(), mass_based_mix);
-    /// # Ok::<(), rfluids::error::Error>(())
+    /// # Ok::<(), rfluids::Error>(())
     /// ```
     #[must_use]
     pub fn into_mole_based(self) -> Self {
@@ -155,6 +156,22 @@ impl CustomMix {
             .keyed_output(MolarMass)
             .unwrap()
     }
+}
+
+/// Error during creation of [`CustomMix`].
+#[derive(Error, Debug, Clone, Eq, PartialEq)]
+pub enum CustomMixError {
+    /// The specified components are not enough.
+    #[error("At least 2 unique components must be provided!")]
+    NotEnoughComponents,
+
+    /// Some of the specified fractions are invalid.
+    #[error("All of the specified fractions must be exclusive between 0 and 1!")]
+    InvalidFraction,
+
+    /// The sum of the specified fractions is invalid.
+    #[error("The sum of the specified fractions must be equal to 1!")]
+    InvalidFractionsSum,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
* Move `StateVariant`'s and `Error` superset into the root module.
* Move errors into corresponding modules.
* Update prelude imports.