### PR TITLE
fix(`coolprop-sys`): runtime linker failure in `coolprop-sys-linux-x86-64` due to SONAME mismatch

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,9 +1,7 @@
 {
   "allowCompoundWords": true,
   "language": "en",
-  "import": [
-    "https://cdn.jsdelivr.net/npm/@cspell/dict-scientific-terms-us/cspell-ext.json"
-  ],
+  "import": ["https://cdn.jsdelivr.net/npm/@cspell/dict-scientific-terms-us/cspell-ext.json"],
   "dictionaries": ["rust", "rust-crates", "scientific-terms-us"],
   "words": [
     "2DPNG",
@@ -32,6 +30,7 @@
     "rustc",
     "SAFT",
     "serde",
+    "SONAME",
     "taiki",
     "trunc",
     "TTSE",

--- a/coolprop-sys-linux-x86-64/build.rs
+++ b/coolprop-sys-linux-x86-64/build.rs
@@ -1,11 +1,13 @@
 use std::{
     env, fs,
+    os::unix,
     path::{Path, PathBuf},
 };
 
 const LIB_PREFIX: &str = "lib";
 const LIB_NAME: &str = "CoolProp";
 const LIB_EXTENSION: &str = ".so";
+const LIB_SONAME: &str = "libCoolProp.so.7";
 
 fn main() {
     println!("cargo:rerun-if-changed=build.rs");
@@ -39,5 +41,13 @@ fn setup_lib(src_dir: &Path, target_dir: &Path) {
     let target_path = target_dir.join(&file_name);
     fs::copy(&src_path, &target_path)
         .expect("Unable to copy CoolProp library to the target directory!");
+    // The library's ELF SONAME is "libCoolProp.so.7", so the runtime linker
+    // looks for that filename rather than "libCoolProp.so". Create a symlink
+    // so it can be found via the rpath set above.
+    let soname_path = target_dir.join(LIB_SONAME);
+    if !soname_path.exists() {
+        unix::fs::symlink(&target_path, &soname_path)
+            .expect("Unable to create SONAME symlink for CoolProp library!");
+    }
     println!("cargo:rustc-link-lib=dylib={}", LIB_NAME);
 }

--- a/coolprop-sys-linux-x86-64/build.rs
+++ b/coolprop-sys-linux-x86-64/build.rs
@@ -1,12 +1,12 @@
 use std::{
     env, fs,
-    os::unix,
     path::{Path, PathBuf},
 };
 
 const LIB_PREFIX: &str = "lib";
 const LIB_NAME: &str = "CoolProp";
 const LIB_EXTENSION: &str = ".so";
+#[allow(unused)]
 const LIB_SONAME: &str = "libCoolProp.so.7";
 
 fn main() {
@@ -41,13 +41,16 @@ fn setup_lib(src_dir: &Path, target_dir: &Path) {
     let target_path = target_dir.join(&file_name);
     fs::copy(&src_path, &target_path)
         .expect("Unable to copy CoolProp library to the target directory!");
-    // The library's ELF SONAME is "libCoolProp.so.7", so the runtime linker
-    // looks for that filename rather than "libCoolProp.so". Create a symlink
-    // so it can be found via the rpath set above.
-    let soname_path = target_dir.join(LIB_SONAME);
-    if !soname_path.exists() {
-        unix::fs::symlink(&target_path, &soname_path)
-            .expect("Unable to create SONAME symlink for CoolProp library!");
+    #[cfg(unix)]
+    {
+        // The library's ELF SONAME is "libCoolProp.so.7", so the runtime linker
+        // looks for that filename rather than "libCoolProp.so". Create a symlink
+        // so it can be found via the rpath set above.
+        let soname_path = target_dir.join(LIB_SONAME);
+        if !soname_path.exists() {
+            std::os::unix::fs::symlink(&target_path, &soname_path)
+                .expect("Unable to create SONAME symlink for CoolProp library!");
+        }
     }
     println!("cargo:rustc-link-lib=dylib={}", LIB_NAME);
 }


### PR DESCRIPTION
The `coolprop-sys-linux-x86-64` build script copies `libCoolProp.so` into `OUT_DIR` and sets rpath to that directory. However, the library's ELF SONAME is `libCoolProp.so.7`, so the runtime linker looks for that filename instead. This causes dependents to fail at runtime:

```
error while loading shared libraries: libCoolProp.so.7: cannot open shared object file
```

This PR adds a `libCoolProp.so.7 -> libCoolProp.so` symlink in `OUT_DIR` after the copy so the runtime linker can find it. Only affects Linux since SONAME is an ELF convention.
